### PR TITLE
improve AppDispatch type safety

### DIFF
--- a/app/store.ts
+++ b/app/store.ts
@@ -13,6 +13,7 @@ import { walletSelectorReducer } from "./modules/wallet-selector/reducer";
 import { TAction } from "./modules/actions";
 import { authReducer } from "./modules/auth/reducer";
 import { signMessageModalReducer } from "./modules/signMessageModal/reducer";
+import { FunctionWithDeps } from "./types";
 
 export interface IAppAction {
   type: string;
@@ -21,7 +22,7 @@ export interface IAppAction {
 export type ActionType<T extends IAppAction> = T["type"];
 export type ActionPayload<T extends IAppAction> = T["payload"];
 
-export type AppDispatch = (a: AppActionTypes | Function) => void;
+export type AppDispatch = (a: AppActionTypes | FunctionWithDeps) => void;
 
 export type AppReducer<S> = (state: Readonly<S> | undefined, action: AppActionTypes) => S;
 


### PR DESCRIPTION
You can do `dispatch(someFlow)` (which is injectedFn), or `dispatch(actions.some.action())` (invoke action creator and get simple object in return)  but you can't do `dispatch(actions.some.action)` (which means you forgot to call action creator). Now you will get compile time error in case of a mistake. 