### PR TITLE
Fix wrong progress bar scalling

### DIFF
--- a/app/components/shared/PercentageIndicator.stories.tsx
+++ b/app/components/shared/PercentageIndicator.stories.tsx
@@ -4,5 +4,8 @@ import * as React from "react";
 import { PercentageIndicatorBar } from "./PercentageIndicatorBar";
 
 storiesOf("PercentageIndicator (Progress)", module)
-  .add("default", () => <PercentageIndicatorBar percent={77} />)
+  .add("100%", () => <PercentageIndicatorBar percent={100} />)
+  .add("77%", () => <PercentageIndicatorBar percent={77} />)
+  .add("5%", () => <PercentageIndicatorBar percent={5} />)
+  .add("1%", () => <PercentageIndicatorBar percent={1} />)
   .add("empty", () => <PercentageIndicatorBar percent={0} />);

--- a/app/components/shared/PercentageIndicatorBar.module.scss
+++ b/app/components/shared/PercentageIndicatorBar.module.scss
@@ -15,10 +15,11 @@
 
   .progress {
     fill: currentColor;
-    transition: 500ms ease-in-out width;
+    transition: 500ms ease-in-out transform;
   }
 
   .background {
+    width: 100%;
     fill: $gray9;
   }
 }

--- a/app/components/shared/PercentageIndicatorBar.tsx
+++ b/app/components/shared/PercentageIndicatorBar.tsx
@@ -43,10 +43,10 @@ export const PercentageIndicatorBar: React.SFC<IProps & CommonHtmlProps> = props
       <span className={styles.label} data-test-id="percentage-indicator-bar-value">
         {percent}%
       </span>
-      <svg width="100%" height="38" viewBox="0 0 450 38" preserveAspectRatio="none">
+      <svg width="100%" height="38">
         <defs>
           <clipPath id="percent-indicator-bar">
-            <rect className={styles.background} width="450" height="38" rx={CURVE} ry={CURVE} />
+            <rect className={styles.background} width="100%" height="38" rx={CURVE} ry={CURVE} />
           </clipPath>
         </defs>
         <g clipPath="url(#percent-indicator-bar)">
@@ -55,9 +55,9 @@ export const PercentageIndicatorBar: React.SFC<IProps & CommonHtmlProps> = props
             className={styles.progress}
             width="100%"
             height="100%"
-            transform={`translate(${percent / 100 * 450 - 450}, 0)`}
             rx={CURVE}
             ry={CURVE}
+            style={{ transform: `translateX(${percent - 100}%)` }}
           />
         </g>
       </svg>

--- a/app/components/shared/PercentageIndicatorBar.tsx
+++ b/app/components/shared/PercentageIndicatorBar.tsx
@@ -43,7 +43,7 @@ export const PercentageIndicatorBar: React.SFC<IProps & CommonHtmlProps> = props
       <span className={styles.label} data-test-id="percentage-indicator-bar-value">
         {percent}%
       </span>
-      <svg width="450" height="38" viewBox="0 0 450 38" preserveAspectRatio="none">
+      <svg width="100%" height="38" viewBox="0 0 450 38" preserveAspectRatio="none">
         <defs>
           <clipPath id="percent-indicator-bar">
             <rect className={styles.background} width="450" height="38" rx={CURVE} ry={CURVE} />

--- a/app/components/shared/PercentageIndicatorBar.tsx
+++ b/app/components/shared/PercentageIndicatorBar.tsx
@@ -43,15 +43,23 @@ export const PercentageIndicatorBar: React.SFC<IProps & CommonHtmlProps> = props
       <span className={styles.label} data-test-id="percentage-indicator-bar-value">
         {percent}%
       </span>
-      <svg width="100%" height="38">
-        <rect className={styles.background} width="100%" height="100%" rx={CURVE} ry={CURVE} />
-        <rect
-          className={styles.progress}
-          width={`${percent}%`}
-          height="100%"
-          rx={CURVE}
-          ry={CURVE}
-        />
+      <svg width="450" height="38" viewBox="0 0 450 38" preserveAspectRatio="none">
+        <defs>
+          <clipPath id="percent-indicator-bar">
+            <rect className={styles.background} width="450" height="38" rx={CURVE} ry={CURVE} />
+          </clipPath>
+        </defs>
+        <g clipPath="url(#percent-indicator-bar)">
+          <rect className={styles.background} height="100%" rx={CURVE} ry={CURVE} />
+          <rect
+            className={styles.progress}
+            width="100%"
+            height="100%"
+            transform={`translate(${percent / 100 * 450 - 450}, 0)`}
+            rx={CURVE}
+            ry={CURVE}
+          />
+        </g>
       </svg>
     </div>
   );


### PR DESCRIPTION
BEFORE:
<img width="477" alt="screen shot 2018-06-25 at 16 20 56" src="https://user-images.githubusercontent.com/12571855/41856705-099f5afe-7896-11e8-9563-453646adbca0.png">
<img width="479" alt="screen shot 2018-06-25 at 16 21 52" src="https://user-images.githubusercontent.com/12571855/41856707-09bef8be-7896-11e8-84b1-ba2100c719aa.png">

AFTER:
<img width="474" alt="screen shot 2018-06-25 at 16 25 57" src="https://user-images.githubusercontent.com/12571855/41856703-0961a330-7896-11e8-929b-774e22a4cd40.png">
<img width="502" alt="screen shot 2018-06-25 at 16 19 55" src="https://user-images.githubusercontent.com/12571855/41856704-09801464-7896-11e8-839a-b6c62d9a48f1.png">
