### PR TITLE
enables parity signup and transaction

### DIFF
--- a/app/components/walletSelector/WalletSelector.integration.spec.tsx
+++ b/app/components/walletSelector/WalletSelector.integration.spec.tsx
@@ -42,11 +42,12 @@ describe("Wallet selector integration", () => {
     const expectedDerivationPath = "44'/60'/0'/1";
     const expectedAddress = dummyEthereumAddress;
     const expectedChallenge = "CHALLENGE";
+
     const ledgerWalletMock = createMock(LedgerWallet, {
       walletType: WalletType.LEDGER,
       walletSubType: WalletSubType.UNKNOWN,
-      signerType: SignerType.ETH_SIGN,
       ethereumAddress: expectedAddress,
+      getSignerType: () => SignerType.ETH_SIGN,
       testConnection: async () => false,
       getMetadata: (): ILedgerWalletMetadata => ({
         walletType: WalletType.LEDGER,
@@ -191,7 +192,7 @@ describe("Wallet selector integration", () => {
       walletType: WalletType.BROWSER,
       walletSubType: WalletSubType.METAMASK,
       ethereumAddress: expectedAddress,
-      signerType: SignerType.ETH_SIGN_TYPED_DATA,
+      getSignerType: () => SignerType.ETH_SIGN_TYPED_DATA,
       getMetadata: (): IBrowserWalletMetadata => ({
         walletType: WalletType.BROWSER,
         address: expectedAddress,

--- a/app/lib/web3/BrowserWallet.ts
+++ b/app/lib/web3/BrowserWallet.ts
@@ -136,10 +136,7 @@ export function parseBrowserWalletError(error: any): BrowserWalletError {
     return new BrowserWalletConfirmationRejectedError();
   }
   // detect Parity rejection
-  if (
-    error.message !== undefined &&
-    error.message.startsWith("Request has been rejected.")
-  ) {
+  if (error.message !== undefined && error.message.startsWith("Request has been rejected.")) {
     return new BrowserWalletConfirmationRejectedError();
   }
 

--- a/app/lib/web3/LedgerWallet.ts
+++ b/app/lib/web3/LedgerWallet.ts
@@ -43,7 +43,6 @@ export class LedgerUnknownError extends LedgerError {}
 export class LedgerWallet implements IPersonalWallet {
   public readonly walletType = WalletType.LEDGER;
   public readonly walletSubType = WalletSubType.UNKNOWN; // in future we may detect if it's pure ledger or Neukey
-  public readonly signerType = SignerType.ETH_SIGN;
   waitingForCommand = false; // if ledger is waiting for user interaction it is blocked and you should not send any instructions to it.
 
   public constructor(
@@ -52,6 +51,10 @@ export class LedgerWallet implements IPersonalWallet {
     private readonly ledgerInstance: any | undefined,
     public readonly derivationPath: string,
   ) {}
+
+  public getSignerType(): SignerType {
+    return SignerType.ETH_SIGN;
+  }
 
   public async testConnection(): Promise<boolean> {
     if (this.waitingForCommand) {

--- a/app/lib/web3/LightWallet.ts
+++ b/app/lib/web3/LightWallet.ts
@@ -185,7 +185,10 @@ export class LightWallet implements IPersonalWallet {
 
   public readonly walletType = WalletType.LIGHT;
   public readonly walletSubType = WalletSubType.UNKNOWN;
-  public readonly signerType = SignerType.ETH_SIGN;
+
+  public getSignerType(): SignerType {
+    return SignerType.ETH_SIGN;
+  }
 
   public async testConnection(networkId: string): Promise<boolean> {
     const currentNetworkId = await this.web3Adapter.getNetworkId();

--- a/app/lib/web3/PersonalWeb3.ts
+++ b/app/lib/web3/PersonalWeb3.ts
@@ -16,7 +16,9 @@ export interface IPersonalWallet {
   readonly ethereumAddress: EthereumAddress;
   readonly walletType: WalletType;
   readonly walletSubType: WalletSubType;
-  readonly signerType: SignerType;
+
+  // returns type of a signer based on walletType and walletSubType
+  getSignerType(): SignerType;
 
   // this will be periodically ran by Web3Manager to ensure that wallet connection is still established
   testConnection(networkId: EthereumNetworkId): Promise<boolean>;

--- a/app/modules/auth/sagas.spec.ts
+++ b/app/modules/auth/sagas.spec.ts
@@ -35,7 +35,7 @@ describe("Jwt actions", () => {
 
       const browserWalletMock = createMock(BrowserWallet, {
         signMessage: async () => expectedSignedMessage,
-        signerType: expectedSignerType,
+        getSignerType: () => expectedSignerType,
       });
       const web3ManagerMock = createMock(Web3Manager, {
         personalWallet: browserWalletMock,

--- a/app/modules/auth/sagas.ts
+++ b/app/modules/auth/sagas.ts
@@ -245,7 +245,7 @@ export async function obtainJwtPromise(
   const salt = cryptoRandomString(64);
 
   /* tslint:disable: no-useless-cast */
-  const signerType = web3Manager.personalWallet!.signerType;
+  const signerType = web3Manager.personalWallet!.getSignerType();
   /* tslint:enable: no-useless-cast */
 
   logger.info("Obtaining auth challenge from api");


### PR DESCRIPTION
how to test
1. install extension https://chrome.google.com/webstore/detail/parity-ethereum-integrati/himekenlppkgeaoeddcliojfddemadig?hl=en
2. run backend locally or if you test just sign-up run instant seal parity container
3. select wallet in parity (selecting from extension popup fails in my browser)
4. disable metamask
5. parity signer will appear when sign message will be sent to the signer

ad 2. extension works with just local parity node - maybe a proxy can be set up to work agains io node which will be best way to do it. we can try to attach light client to stage