### PR TITLE
enables investment flow after state refactor

### DIFF
--- a/app/modules/public-etos/sagas.ts
+++ b/app/modules/public-etos/sagas.ts
@@ -1,6 +1,7 @@
 import BigNumber from "bignumber.js";
 import { compose, keyBy, map, omit } from "lodash/fp";
 import { all, fork, put, select } from "redux-saga/effects";
+import { promisify } from "../../lib/contracts/typechain-runtime";
 
 import { TGlobalDependencies } from "../../di/setupBindings";
 import { IHttpResponse } from "../../lib/api/client/IHttpClient";
@@ -156,11 +157,12 @@ export function* loadComputedContributionFromContract(
       amountEuroUlps || convertToBigInt((eto.minTicketEur && eto.minTicketEur.toString()) || "0");
 
     const from = selectEthereumAddressWithChecksum(state.web3);
-    const calculation = yield etoContract.calculateContribution(
+    // sorry no typechain, typechain has a bug with boolean casting
+    const calculation = yield promisify(etoContract.rawWeb3Contract.calculateContribution, [
       from,
       isICBM,
       new BigNumber(amountEuroUlps),
-    );
+    ]);
     yield put(
       actions.publicEtos.setCalculatedContribution(
         eto.previewCode,

--- a/app/modules/public-etos/selectors.ts
+++ b/app/modules/public-etos/selectors.ts
@@ -18,7 +18,9 @@ const selectEtoPreviewCode = (state: IPublicEtoState, etoId: string) => {
 export const selectEto = (state: IPublicEtoState, previewCode: string) =>
   state.publicEtos[previewCode];
 
-export const selectEtoById = (state: IPublicEtoState, etoId: string) => state.publicEtos[etoId];
+export const selectEtoById = (state: IPublicEtoState, etoId: string) => {
+  return state.publicEtos[selectEtoPreviewCode(state, etoId)!];
+};
 
 export const selectCalculatedContributionByEtoId = (etoId: string, state: IPublicEtoState) => {
   const previewCode = selectEtoPreviewCode(state, etoId);

--- a/app/modules/tx/transactionsGenerators/investment/sagas.ts
+++ b/app/modules/tx/transactionsGenerators/investment/sagas.ts
@@ -67,7 +67,7 @@ function getEtherTokenTransaction(
     ].getData(etoId, i.ethValueUlps, "");
     txDetails = createTxData(state, txInput, contractsService.etherToken.address);
 
-    // fill up etherToken with ether from walle}t
+    // fill up etherToken with ether from wallet
   } else {
     const ethVal = new BigNumber(i.ethValueUlps);
     const difference = ethVal.sub(etherTokenBalance);


### PR DESCRIPTION
preview id is now used as eto id in state (and it's good because it never changes!). this required a fix in one of the selectors that assumed contract address is used