### PR TITLE
fixes waiting for pending transaction

### DIFF
--- a/app/components/wallet/wallet-balance/IcbmWallet.tsx
+++ b/app/components/wallet/wallet-balance/IcbmWallet.tsx
@@ -47,7 +47,7 @@ export const IcbmWallet: React.SFC<IIcbmWallet> = ({
             currencyTotal="eur"
             largeNumber={data.neuroAmount}
             value={data.neuroEuroAmount}
-            onUpgradeClick={data.neuroEuroAmount === "0" ? undefined : onUpgradeEuroClick}
+            onUpgradeClick={data.isEuroUpgradeTargetSet ? onUpgradeEuroClick : undefined}
             disabled={!data.isEuroUpgradeTargetSet}
           />
         )}
@@ -60,7 +60,7 @@ export const IcbmWallet: React.SFC<IIcbmWallet> = ({
             currencyTotal="eur"
             largeNumber={data.ethAmount}
             value={data.ethEuroAmount}
-            onUpgradeClick={data.ethAmount === "0" ? undefined : onUpgradeEtherClick}
+            onUpgradeClick={data.isEtherUpgradeTargetSet ? onUpgradeEtherClick : undefined}
             disabled={!data.isEtherUpgradeTargetSet}
           />
         )}


### PR DESCRIPTION
out of bound transaction has a type `mempool` not an empty type... I think we introduced it to easily mock an e2e test that would create such entry on the backend and then delete it...

anyway here is a fix

also fixes UPGRADE WALLET visible when there's no migration target