### PR TITLE
aligns with new contracts signatures

### DIFF
--- a/app/modules/investor-tickets/types.ts
+++ b/app/modules/investor-tickets/types.ts
@@ -16,6 +16,7 @@ export interface IInvestorTicket {
 
 export interface ICalculatedContribution {
   isWhitelisted: boolean;
+  isEligible: boolean;
   minTicketEurUlps: BigNumber;
   maxTicketEurUlps: BigNumber;
   equityTokenInt: BigNumber;

--- a/app/modules/investor-tickets/utils.ts
+++ b/app/modules/investor-tickets/utils.ts
@@ -4,13 +4,23 @@ import { ICalculatedContribution, IInvestorTicket } from "./types";
 
 export const convertToCalculatedContribution = ([
   isWhitelisted,
+  isEligible,
   minTicketEurUlps,
   maxTicketEurUlps,
   equityTokenInt,
   neuRewardUlps,
   maxCapExceeded,
-]: [boolean, BigNumber, BigNumber, BigNumber, BigNumber, boolean]): ICalculatedContribution => ({
+]: [
+  boolean,
+  boolean,
+  BigNumber,
+  BigNumber,
+  BigNumber,
+  BigNumber,
+  boolean
+]): ICalculatedContribution => ({
   isWhitelisted,
+  isEligible,
   minTicketEurUlps,
   maxTicketEurUlps,
   equityTokenInt,

--- a/e2e/setup-e2e.sh
+++ b/e2e/setup-e2e.sh
@@ -2,7 +2,7 @@
 set -e
 cd "$(dirname "$0")"
 
-BACKEND_SHA=da3ad54598033fae1fe08b8a27b063dca376399e
+BACKEND_SHA=91ec913a58785c1421c56888cf8e2b58119e9ec4
 
 # we tag images with shorter SHA
 BACKEND_SHORT_SHA=${BACKEND_SHA:0:7}
@@ -83,7 +83,7 @@ if lsof -Pi :5001 -sTCP:LISTEN -t > /dev/null ; then
     echo "Detected already started backend..."
 else
     echo "Starting up backend..."
-    until run_backend 
+    until run_backend
     do
         echo "Try again"
     done


### PR DESCRIPTION
some changes were required to handle non retail eto, in particular in `calculateContribution`. this PR fixes this and allows to connect to backend deployed on .io again