### PR TITLE
Reduce number of cypress retries

### DIFF
--- a/cypress/cypress-retries.js
+++ b/cypress/cypress-retries.js
@@ -10,7 +10,7 @@ const _ = require("lodash");
 // This script was taken from issue 1313 in Cypress
 // https://github.com/cypress-io/cypress/issues/1313
 
-const MAX_NUM_RUNS = 3;
+const MAX_NUM_RUNS = 2;
 
 const DEFAULT_CONFIG = {
   // you can omit 'spec' if you just want all your tests to run


### PR DESCRIPTION
When number of E2E test retries is greater than one cypress replies with 
```

Run #2 failed.
Retrying '1' specs...
[ 'app/test-e2e/eto/InvestWithUpgradedWalletEther.spec.e2e.ts' ]
Xlib:  extension "RANDR" missing on display ":99".
Xlib:  extension "RANDR" missing on display ":99".
The run you are attempting to access is already complete and will not accept new groups.

The existing run is: https://dashboard.cypress.io/#/projects/r5nj5t/runs/1213

When a run finishes all of its groups, it waits for a configurable set of time before finally completing. You must add more groups during that time period.

The --group flag you passed was: main: retry #2  (1 spec on 012c1a)
The --parallel flag you passed was: true

https://on.cypress.io/already-complete
```
And this generates a false positive