### PR TITLE
#1979 remove "error getting pending transactions" notification

### DIFF
--- a/app/modules/tx/monitor/sagas.ts
+++ b/app/modules/tx/monitor/sagas.ts
@@ -42,13 +42,12 @@ export function* updateTxs(): any {
   yield put(actions.txMonitor.setPendingTxs(apiPendingTx));
 }
 
-function* txMonitor({ logger, notificationCenter }: TGlobalDependencies): any {
+function* txMonitor({ logger }: TGlobalDependencies): any {
   while (true) {
     logger.info("Querying for pending txs...");
     try {
       yield neuCall(updateTxs);
     } catch (e) {
-      notificationCenter.error("Error while trying to get pending transactions");
       logger.error("Error getting pending txs", e);
     }
 


### PR DESCRIPTION
remove notification popup but leave logging in place
it's our internal technical stuff, it only confuses the user