### PR TITLE
add star to date of birth

### DIFF
--- a/intl/locales/en-en.json
+++ b/intl/locales/en-en.json
@@ -374,7 +374,7 @@
   "form.field.error.us-citizen": "We are very sorry, at the moment we cannot serve US customers due to regulatory uncertainties",
   "form.field.error.younger-than": "You must be younger than {age} years",
   "form.label.address": "Address",
-  "form.label.birth-date": "Date of birth",
+  "form.label.birth-date": "Date of birth *",
   "form.label.city": "City",
   "form.label.company-name": "Company name",
   "form.label.company-registration-number": "Company registration number (if applicable)",


### PR DESCRIPTION
This adds the "required" start to date of birth in kyc. This is not the reighit way, the date field should detect this automatically, but as this has to go in for the release, this is the quick fix.