### PR TITLE
#2073_Remove double header from light wallet recovery

### DIFF
--- a/app/components/wallet-selector/light/RegisterLightWallet.module.scss
+++ b/app/components/wallet-selector/light/RegisterLightWallet.module.scss
@@ -8,4 +8,5 @@
 
 .note {
   @include font-button-small;
+  text-align: center;
 }

--- a/app/components/wallet-selector/light/RegisterLightWallet.tsx
+++ b/app/components/wallet-selector/light/RegisterLightWallet.tsx
@@ -120,20 +120,19 @@ export const RegisterWalletComponent: React.SFC<
   IDispatchProps & IStateProps & { restore: boolean }
 > = props => (
   <>
-    <h2
-      className={cn(styles.title, "text-center mb-4")}
-      data-test-id="modals.wallet-selector.register-restore-light-wallet.title"
-    >
-      {props.restore ? (
-        <FormattedMessage id="wallet-selector.neuwallet.restore-prompt" />
-      ) : (
-        <FormattedMessage id="wallet-selector.neuwallet.register-prompt" />
-      )}
-    </h2>
-    <p className={styles.explanation}>
-      <FormattedMessage tagName="span" id="wallet-selector.neuwallet.explanation-1" />
-    </p>
-
+    {props.restore ? null : (
+      <>
+        <h2
+          className={cn(styles.title, "text-center mb-4")}
+          data-test-id="modals.wallet-selector.register-restore-light-wallet.title"
+        >
+          <FormattedMessage id="wallet-selector.neuwallet.register-prompt" />
+        </h2>
+        <p className={styles.explanation}>
+          <FormattedMessage tagName="span" id="wallet-selector.neuwallet.explanation-1" />
+        </p>
+      </>
+    )}
     <Row>
       <Col md={{ size: 8, offset: 2 }}>
         <RegisterEnhancedLightWalletForm {...props} />

--- a/intl/locales/en-en.json
+++ b/intl/locales/en-en.json
@@ -904,7 +904,6 @@
   "wallet-selector.neuwallet.register-link-text": "You don't have an account?",
   "wallet-selector.neuwallet.register-prompt": "New to blockchain? Create a Light Wallet",
   "wallet-selector.neuwallet.restore": "Restore",
-  "wallet-selector.neuwallet.restore-prompt": "Restore your Light Wallet",
   "wallet-selector.neuwallet.welcome": "Login with your Light Wallet",
   "wallet-selector.recover.help.contact-for-help": "Do you need help? Click here",
   "wallet-selector.recover.help.email-login": "Before proceeding with wallet recovery, we recommend checking your inbox (or spam folder) for the access link you received after creating your Light Wallet",


### PR DESCRIPTION
remove header and explanation from RegisterLightWallet component if it's recovery.
fix css for footnote.