### PR TITLE
Turn on TypeScript import helpers

### DIFF
--- a/package.json
+++ b/package.json
@@ -242,6 +242,7 @@
     "semver": "^5.4.1",
     "slick-carousel": "^1.8.1",
     "text-mask-addons": "^3.8.0",
+    "tslib": "^1.9.3",
     "tweetnacl": "^1.0.0",
     "tweetnacl-util": "^0.15.0",
     "url-join": "^3.0.0",

--- a/tsconfig.cypress.json
+++ b/tsconfig.cypress.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "strict": true,
     "noImplicitAny": false,
+    "importHelpers": true,
     "target": "es2015",
     "moduleResolution": "Node",
     "types": ["cypress"],

--- a/tsconfig.dev.json
+++ b/tsconfig.dev.json
@@ -3,6 +3,7 @@
     "target": "es2017",
     "module": "commonjs",
     "strict": true,
+    "importHelpers": true,
     "noImplicitThis": true,
     "alwaysStrict": true,
     "experimentalDecorators": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
     "target": "es2016",
     "module": "commonjs",
     "strict": true,
+    "importHelpers": true,
     "noImplicitThis": true,
     "alwaysStrict": true,
     "experimentalDecorators": true,


### PR DESCRIPTION
Generally, this will move typescript generated code like `__extends` and `__assign` to separate module those will save a little bit of main bundle size.