### PR TITLE
At/enable accept tos by default

### DIFF
--- a/app/components/modals/accept-tos-modal/AcceptTosModal.tsx
+++ b/app/components/modals/accept-tos-modal/AcceptTosModal.tsx
@@ -26,24 +26,8 @@ interface IDispatchProps {
   onLogout: (userType?: EUserType) => void;
 }
 
-interface IState {
-  tosDownloaded: boolean;
-}
-
-export class AcceptTosModalInner extends React.Component<IStateProps & IDispatchProps, IState> {
-  state = {
-    tosDownloaded: false,
-  };
-
-  onDownloadTos = () => {
-    this.setState({
-      tosDownloaded: true,
-    });
-    this.props.onDownloadTos();
-  };
-
-  render(): React.ReactNode {
-    const { userType, onLogout, onAccept, agreementChanged } = this.props;
+export const AcceptTosModalInner:React.ComponentType<IStateProps & IDispatchProps> =
+  ({onDownloadTos, userType, onLogout, onAccept, agreementChanged}) => {
     return (
       <section className="text-center">
         <h1>
@@ -58,7 +42,7 @@ export class AcceptTosModalInner extends React.Component<IStateProps & IDispatch
         </p>
         <div className="mt-2 mb-2">
           <Button
-            onClick={this.onDownloadTos}
+            onClick={onDownloadTos}
             layout={EButtonLayout.SECONDARY}
             data-test-id="modals.accept-tos.download-button"
           >
@@ -69,7 +53,6 @@ export class AcceptTosModalInner extends React.Component<IStateProps & IDispatch
           <Button
             onClick={onAccept}
             layout={EButtonLayout.PRIMARY}
-            disabled={!this.state.tosDownloaded}
             data-test-id="modals.accept-tos.accept-button"
           >
             <FormattedMessage id="settings.modal.accept-tos.accept-button" />
@@ -89,8 +72,7 @@ export class AcceptTosModalInner extends React.Component<IStateProps & IDispatch
         />
       </section>
     );
-  }
-}
+};
 
 const AcceptTosModalComponent: React.FunctionComponent<IStateProps & IDispatchProps> = props => (
   <Modal isOpen={props.isOpen} centered>

--- a/app/components/modals/accept-tos-modal/AcceptTosModal.tsx
+++ b/app/components/modals/accept-tos-modal/AcceptTosModal.tsx
@@ -26,52 +26,57 @@ interface IDispatchProps {
   onLogout: (userType?: EUserType) => void;
 }
 
-export const AcceptTosModalInner:React.ComponentType<IStateProps & IDispatchProps> =
-  ({onDownloadTos, userType, onLogout, onAccept, agreementChanged}) => {
-    return (
-      <section className="text-center">
-        <h1>
-          {agreementChanged ? (
-            <FormattedHTMLMessage tagName="span" id="settings.modal.accept-updated-tos.title" />
-          ) : (
-            <FormattedMessage id="settings.modal.accept-tos.title" />
-          )}
-        </h1>
-        <p className="mt-4 mb-2">
-          <FormattedMessage id="settings.modal.accept-tos.text" />
-        </p>
-        <div className="mt-2 mb-2">
-          <Button
-            onClick={onDownloadTos}
-            layout={EButtonLayout.SECONDARY}
-            data-test-id="modals.accept-tos.download-button"
-          >
-            <FormattedMessage id="settings.modal.accept-tos.download-button" />
-          </Button>
-        </div>
-        <div className="mt-4 mb-2">
-          <Button
-            onClick={onAccept}
-            layout={EButtonLayout.PRIMARY}
-            data-test-id="modals.accept-tos.accept-button"
-          >
-            <FormattedMessage id="settings.modal.accept-tos.accept-button" />
-          </Button>
-        </div>
-        <div>
-          <Button onClick={() => onLogout(userType)} layout={EButtonLayout.SIMPLE}>
-            <FormattedMessage id="settings.modal.accept-tos.logout-button" />
-          </Button>
-        </div>
-        {/* this is a small div element used by the e2e tests to accept the ToU without having to download them, which does not work on electron */}
-        {/* a cleaner solution would be greatly appreciated, force: click does not work here :( */}
-        <div
-          data-test-id="modals.accept-tos.accept-button-hidden"
+export const AcceptTosModalInner: React.ComponentType<IStateProps & IDispatchProps> = ({
+  onDownloadTos,
+  userType,
+  onLogout,
+  onAccept,
+  agreementChanged,
+}) => {
+  return (
+    <section className="text-center">
+      <h1>
+        {agreementChanged ? (
+          <FormattedHTMLMessage tagName="span" id="settings.modal.accept-updated-tos.title" />
+        ) : (
+          <FormattedMessage id="settings.modal.accept-tos.title" />
+        )}
+      </h1>
+      <p className="mt-4 mb-2">
+        <FormattedMessage id="settings.modal.accept-tos.text" />
+      </p>
+      <div className="mt-2 mb-2">
+        <Button
+          onClick={onDownloadTos}
+          layout={EButtonLayout.SECONDARY}
+          data-test-id="modals.accept-tos.download-button"
+        >
+          <FormattedMessage id="settings.modal.accept-tos.download-button" />
+        </Button>
+      </div>
+      <div className="mt-4 mb-2">
+        <Button
           onClick={onAccept}
-          style={{ height: 5 }}
-        />
-      </section>
-    );
+          layout={EButtonLayout.PRIMARY}
+          data-test-id="modals.accept-tos.accept-button"
+        >
+          <FormattedMessage id="settings.modal.accept-tos.accept-button" />
+        </Button>
+      </div>
+      <div>
+        <Button onClick={() => onLogout(userType)} layout={EButtonLayout.SIMPLE}>
+          <FormattedMessage id="settings.modal.accept-tos.logout-button" />
+        </Button>
+      </div>
+      {/* this is a small div element used by the e2e tests to accept the ToU without having to download them, which does not work on electron */}
+      {/* a cleaner solution would be greatly appreciated, force: click does not work here :( */}
+      <div
+        data-test-id="modals.accept-tos.accept-button-hidden"
+        onClick={onAccept}
+        style={{ height: 5 }}
+      />
+    </section>
+  );
 };
 
 const AcceptTosModalComponent: React.FunctionComponent<IStateProps & IDispatchProps> = props => (


### PR DESCRIPTION
there's no easy way to deal with safari opening ToS in the same tab. Even if it opens it in the new tab (target=_blank), the app in the prev. tab gets reloaded. Quick fix is to enable the button by default