### PR TITLE
[hotfix] Fix people swiper widget

### DIFF
--- a/packages/web/app/components/shared/charts/ChartDoughnutLazy.tsx
+++ b/packages/web/app/components/shared/charts/ChartDoughnutLazy.tsx
@@ -1,7 +1,20 @@
 import * as React from "react";
 
-const ChartDoughnutLazy = React.lazy(() =>
+import { LoadingIndicator } from "../loading-indicator/LoadingIndicator";
+
+const ChartDoughnut = React.lazy(() =>
   import("./ChartDoughnut.unsafe").then(imp => ({ default: imp.ChartDoughnut })),
+);
+
+/**
+ * @note We need to wrap lazy loaded chart into suspense to prevent `PeopleSwiperWidget` wrong width calculation bug
+ */
+const ChartDoughnutLazy: React.FunctionComponent<
+  React.ComponentProps<typeof ChartDoughnut>
+> = props => (
+  <React.Suspense fallback={<LoadingIndicator />}>
+    <ChartDoughnut {...props} />
+  </React.Suspense>
 );
 
 export { ChartDoughnutLazy };


### PR DESCRIPTION
Unfortunately, React.Suspense mounts node and adds `style: display: none` which breaks our PeopleSwiperWidget initial width calculation.
Until we migrate to ConcurentMode we should be careful with lazy loading that touches PeopleSwiperWidget component

(cherry picked from commit 07577a0623bc361d619b8ddf456efddbd6e494b7)