### PR TITLE
applies share nominal value to obtain correct price, fixes units

### DIFF
--- a/packages/web/app/components/portfolio/PortfolioMyAssets.tsx
+++ b/packages/web/app/components/portfolio/PortfolioMyAssets.tsx
@@ -132,13 +132,13 @@ const PortfolioMyAssetsComponent: React.FunctionComponent<TComponentProps> = ({
               </span>
               <Money
                 value={multiplyBigNumbers([tokenData.tokenPrice, tokenData.balance])}
-                inputFormat={ENumberInputFormat.FLOAT}
+                inputFormat={ENumberInputFormat.ULPS}
                 valueType={ECurrency.EUR}
                 outputFormat={ENumberOutputFormat.FULL}
               />
               <Money
                 value={tokenData.tokenPrice}
-                inputFormat={ENumberInputFormat.FLOAT}
+                inputFormat={ENumberInputFormat.ULPS}
                 valueType={ECurrency.EUR}
                 outputFormat={ENumberOutputFormat.FULL}
               />


### PR DESCRIPTION
fixes the following unit problem with legacy etos
![image](https://user-images.githubusercontent.com/17202864/64922275-c3843600-d7cd-11e9-957d-2e41f5671ab9.png)

and provides correct calculations for token price. todo; move all calculations to one place