### PR TITLE
corrects #3486 - displays countdown to public sale for unlogged/ineligible investors

### DIFF
--- a/packages/web/app/components/eto/overview/EtoOverviewThumbnail/EtoCardStatusManager.tsx
+++ b/packages/web/app/components/eto/overview/EtoOverviewThumbnail/EtoCardStatusManager.tsx
@@ -1,6 +1,5 @@
 import * as moment from "moment";
 import * as React from "react";
-import { FormattedRelative } from "react-intl";
 import { FormattedMessage } from "react-intl-phraseapp";
 
 import { EEtoState } from "../../../../lib/api/eto/EtoApi.interfaces.unsafe";
@@ -62,23 +61,28 @@ const EtoCardStatusManager = ({ eto }: IExternalProps) => {
     case EETOStateOnChain.Whitelist: {
       const publicSaleStartDate = eto.contract!.startOfStates[EETOStateOnChain.Public]!;
 
-      return (
-        <>
-          <InvestmentStatus eto={eto} />
+      if (eto.subState === EEtoSubState.COUNTDOWN_TO_PUBLIC_SALE) {
+        {
+          /* user is not allowed to invest in presale or user is not logged in */
+        }
+        return (
+          <CounterWidget
+            endDate={publicSaleStartDate}
+            awaitedState={EETOStateOnChain.Public}
+            etoId={eto.etoId}
+          />
+        );
+      } else {
+        return (
+          <>
+            <InvestmentStatus eto={eto} />
 
-          <Info>
-            {/* user is not allowed to invest in presale */}
-            {eto.subState === EEtoSubState.COUNTDOWN_TO_PUBLIC_SALE ? (
-              <FormattedMessage
-                id="eto-overview-thumbnail.presale.days-to-public-sale"
-                values={{ startDate: <FormattedRelative value={publicSaleStartDate} /> }}
-              />
-            ) : (
+            <Info>
               <FormattedMessage id="eto-overview-thumbnail.presale.view-offer" />
-            )}
-          </Info>
-        </>
-      );
+            </Info>
+          </>
+        );
+      }
     }
 
     case EETOStateOnChain.Public: {

--- a/packages/web/intl/locales/en-en.json
+++ b/packages/web/intl/locales/en-en.json
@@ -222,7 +222,6 @@
   "eto-overview-thumbnail.cover.jurisdiction.li": "Liechtenstein offering",
   "eto-overview-thumbnail.funding-round": "Funding Round",
   "eto-overview-thumbnail.headquarters": "Company Headquarters",
-  "eto-overview-thumbnail.presale.days-to-public-sale": "Public sale starts {startDate}",
   "eto-overview-thumbnail.presale.view-offer": "Presale Started - View Offer",
   "eto-overview-thumbnail.public-sale.days-left": "{endDate} until ETO ends - {foundedPercentage}% funded",
   "eto-overview-thumbnail.refund.claim-refund": "CLAIM REFUND",


### PR DESCRIPTION
ticket #3486 specified that pre-sale stats should be visible to unlogged/ineligible investors. that was a mistake that was corrected, please check
https://github.com/Neufund/platform-frontend/issues/3486
for the correction (correct design was put there0

this PR fixes that problem. tested manually on `io` and expected state is there:
![image](https://user-images.githubusercontent.com/17202864/66398822-c514d880-e9de-11e9-8e6d-1be179541db0.png)
