### PR TITLE
[DO NOT MERGE] removes ledger watcher

### DIFF
--- a/packages/web/app/components/wallet-selector/ledger/WalletLedgerChooser.tsx
+++ b/packages/web/app/components/wallet-selector/ledger/WalletLedgerChooser.tsx
@@ -8,7 +8,6 @@ import {
 } from "../../../modules/wallet-selector/ledger-wizard/reducer";
 import { appConnect } from "../../../store";
 import { onEnterAction } from "../../../utils/OnEnterAction";
-import { withActionWatcher } from "../../../utils/withActionWatcher.unsafe";
 import {
   IWalletLedgerChooserComponent,
   IWalletLedgerChooserComponentDispatchProps,
@@ -45,10 +44,5 @@ export const WalletLedgerChooser = compose<React.FunctionComponent>(
   }),
   onEnterAction({
     actionCreator: dispatch => dispatch(actions.walletSelector.ledgerLoadAccounts()),
-  }),
-  withActionWatcher({
-    actionCreator: dispatch =>
-      dispatch(actions.walletSelector.ledgerVerifyIfLedgerStillConnected()),
-    interval: 1000,
   }),
 )(WalletLedgerChooserComponent);

--- a/packages/web/app/lib/web3/Web3Manager/Web3Manager.ts
+++ b/packages/web/app/lib/web3/Web3Manager/Web3Manager.ts
@@ -79,10 +79,12 @@ export class Web3Manager extends EventEmitter {
   }
 
   public async plugPersonalWallet(personalWallet: IPersonalWallet): Promise<void> {
-    const isWalletConnected = await personalWallet.testConnection(this.networkId);
+    // why we are testing connection here? this method is called directly after successful sync
+    // todo: remove
+    /* const isWalletConnected = await personalWallet.testConnection(this.networkId);
     if (!isWalletConnected) {
       throw new WalletNotConnectedError(personalWallet);
-    }
+    }*/
 
     this.personalWallet = personalWallet;
 

--- a/packages/web/app/lib/web3/ledger-wallet/LedgerConnector.ts
+++ b/packages/web/app/lib/web3/ledger-wallet/LedgerConnector.ts
@@ -28,6 +28,13 @@ export class LedgerWalletConnector {
 
   public async connect(): Promise<void> {
     try {
+      // todo: we must change how it works. now we just create new ledger connection
+      // for each call to ledger. that does not make sense
+      // we should simply cache transport instance not a function to take transport
+      // and simply use it but via a method similar to ensureWalletConnection
+      // which will take a method (like getConfig) as side effect and execute it with the open transport
+      // if execution fails due to transport being dead etc. (that we need to detect), we just re-open transport
+      // and try again ONCE. the infinite loop is done by ensureWalletConnection so no worries about it
       this.getTransport = await connectToLedger();
     } catch (e) {
       if (e instanceof LedgerError) {

--- a/packages/web/app/lib/web3/ledger-wallet/ledgerUtils.ts
+++ b/packages/web/app/lib/web3/ledger-wallet/ledgerUtils.ts
@@ -44,8 +44,9 @@ export const obtainPathComponentsFromDerivationPath = (derivationPath: string) =
 
 export const testConnection = async (getTransport: () => any): Promise<boolean> => {
   try {
+    // todo: can always return true or skip on windows 10
     // this check will successfully detect if ledger is locked or disconnected
-    await getLedgerConfig(getTransport);
+    // await getLedgerConfig(getTransport);
     return true;
   } catch {
     return false;
@@ -116,6 +117,8 @@ export const createWeb3WithLedgerProvider = async (
 
 export const connectToLedger = async (): Promise<() => any> => {
   const getTransport = () => TransportU2F.create();
+  // todo: this below must be done just once: at first connection in wallet chooser
+  // we can assume that it's same ledger later on
   const ledgerConfig = await getLedgerConfig(getTransport);
   if (semver.lt(ledgerConfig.version, minimumLedgerVersion)) {
     // We support versions newer than 1.2.4

--- a/packages/web/app/modules/access-wallet/sagas.ts
+++ b/packages/web/app/modules/access-wallet/sagas.ts
@@ -68,6 +68,7 @@ export function* ensureWalletConnection(
   //  - user attaches different ledger device
   const isSameAddress = wallet.ethereumAddress.toLowerCase() === metadata.address.toLowerCase();
   if (!isSameAddress) {
+    // todo: logout user immediately, do not throw errors
     throw new MismatchedWalletAddressError(metadata.address, wallet.ethereumAddress);
   }
 
@@ -79,6 +80,8 @@ async function connectLedger(
   web3Manager: Web3Manager,
   metadata: ILedgerWalletMetadata,
 ): Promise<IPersonalWallet> {
+  // todo: only here do a full connect check (firmware version etc.)
+  // which should be side effect of getting valid transport
   await ledgerWalletConnector.connect();
   return await ledgerWalletConnector.finishConnecting(
     metadata.derivationPath,
@@ -149,6 +152,7 @@ export function* connectWalletAndRunEffect(effect: Effect | Iterator<Effect>): a
       if (e instanceof SignerError || error.messageType === GenericErrorMessage.GENERIC_ERROR)
         throw e;
 
+      // todo: clear chance to have infinite loop. please explain how this saga is cancelled
       yield delay(500);
     }
   }

--- a/packages/web/app/modules/wallet-selector/ledger-wizard/sagas.ts
+++ b/packages/web/app/modules/wallet-selector/ledger-wizard/sagas.ts
@@ -99,16 +99,16 @@ export function* goToPreviousPageAndLoadData(): any {
   yield put(actions.walletSelector.ledgerLoadAccounts());
 }
 
-export function* finishSettingUpLedgerConnector(
-  { ledgerWalletConnector, web3Manager }: TGlobalDependencies,
-  action: TAction,
-): any {
+export function* finishSettingUpLedgerConnector({ ledgerWalletConnector, web3Manager }: TGlobalDependencies, action: TAction): any {
   if (action.type !== "LEDGER_FINISH_SETTING_UP_LEDGER_CONNECTOR") return;
-  const ledgerWallet = yield ledgerWalletConnector.finishConnecting(
+  // todo: why this is done here and in saga? (access-wallet).
+  // this saga is clearly called when doing first connection so what's the point of doing it here?
+  /*const ledgerWallet = yield ledgerWalletConnector.finishConnecting(
     action.payload.derivationPath,
     web3Manager.networkId,
-  );
-  yield web3Manager.plugPersonalWallet(ledgerWallet);
+  );*/
+  // todo: see ensureWalletConnection - all of this is done there
+  // yield web3Manager.plugPersonalWallet(ledgerWallet);
   yield put(actions.walletSelector.connected());
 }
 
@@ -137,5 +137,7 @@ export function* ledgerSagas(): Iterator<any> {
     "LEDGER_FINISH_SETTING_UP_LEDGER_CONNECTOR",
     finishSettingUpLedgerConnector,
   );
-  yield fork(neuTakeEvery, "LEDGER_VERIFY_IF_LEDGER_STILL_CONNECTED", verifyIfLedgerStillConnected);
+  // it's the third place that checks if ledger is stil connected. first in WalletLedgerChooser,
+  // then there's a wallet watched in web3ConnectionWatcher, now this
+  // yield fork(neuTakeEvery, "LEDGER_VERIFY_IF_LEDGER_STILL_CONNECTED", verifyIfLedgerStillConnected);
 }


### PR DESCRIPTION
objectives
1. read the code review in the PR
2. we have too many watchers for the ledger connection started from many different places. like 5?
3. some of the watchers do not wait for action to be completed and just reissue connection. this should not happen
4. this applies to ledger and browser wallet IMO
5. those actions and connection establishing in the loop - does not seem there's a way to cancel them!

ledger fix
1. minimize transport creation as per comments in PR. we can cache opened transport and reopen it seamlessly on error. that will minimize popups on windows (and is also a good practice)
2. we check firmware and do other checks on every transport open. does not make sense. IMO this is why ledger slowed down recently (if you cahce transport then we can check it for every new transport obtained to detect connecting different ledger)
3. consider dropping testing connection on ledger altogether but for sure on windows machines

the windows popup happens when transport.create() is called. this needs to be minimized

we also have a timeout parameter when creating transport. please investigate if we can use long timeout periods