### PR TITLE
uses dummy block tracker for wallet engine

### DIFF
--- a/packages/web/app/lib/web3/DummyBlockTracker.ts
+++ b/packages/web/app/lib/web3/DummyBlockTracker.ts
@@ -1,0 +1,7 @@
+import { EventEmitter } from "events";
+
+export class DummyBlockTracker extends EventEmitter {
+  public async start(): Promise<void> {}
+
+  public async stop(): Promise<void> {}
+}

--- a/packages/web/app/lib/web3/ledger-wallet/ledgerUtils.ts
+++ b/packages/web/app/lib/web3/ledger-wallet/ledgerUtils.ts
@@ -8,6 +8,7 @@ import * as Web3ProviderEngine from "web3-provider-engine";
 import * as RpcSubprovider from "web3-provider-engine/subproviders/rpc";
 
 import { promisify } from "../../../utils/PromiseUtils";
+import { DummyBlockTracker } from "./../DummyBlockTracker";
 import {
   LedgerContractsDisabledError,
   LedgerNotAvailableError,
@@ -73,7 +74,7 @@ export const createWeb3WithLedgerProvider = async (
   getTransport: () => any,
   derivationPath: string,
 ): Promise<ILedgerOutput> => {
-  const engine = new Web3ProviderEngine();
+  const engine = new Web3ProviderEngine({ blockTracker: new DummyBlockTracker() });
 
   const ledgerProvider = createLedgerSubprovider(getTransport, {
     networkId,

--- a/packages/web/app/lib/web3/light-wallet/LightWalletConnector.ts
+++ b/packages/web/app/lib/web3/light-wallet/LightWalletConnector.ts
@@ -14,6 +14,7 @@ import { EthereumAddress } from "../../../utils/opaque-types/types";
 import { ILogger } from "../../dependencies/logger";
 import { IPersonalWallet } from "../PersonalWeb3";
 import { STIPEND_ELIGIBLE_WALLETS } from "./../constants";
+import { DummyBlockTracker } from "./../DummyBlockTracker";
 import { IEthereumNetworkConfig } from "./../types";
 import { Web3Adapter } from "./../Web3Adapter";
 import {
@@ -79,7 +80,7 @@ export class LightWalletConnector {
           return;
         },
       });
-      engine = new Web3ProviderEngine();
+      engine = new Web3ProviderEngine({ blockTracker: new DummyBlockTracker() });
       engine.addProvider(web3Provider);
       engine.addProvider(
         new RpcSubprovider({


### PR DESCRIPTION
**What it does**
Prevents downloading any blocks by the wallet engine. Default implementation requests blocks with all transactions included which can be quite large. Now no blocks will be downloaded at ll.

**Why we do it**
We now route such requests through our backend and this has lower performance than our load balanced nodes. From user perspective you often wait for many seconds after clicking login button because (somehow) engine waits for first block to be downloaded...